### PR TITLE
Chore: Better README format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
 # bertin.js
 
-_Bertin.js is <ins>**under development**</ins> so not necessarily very stable yet. The names of the functions and the parameters are still subject to change. Bugs will be corrected as they occur. New features will be added in the next versions._
+**Bertin.js** is a JavaScript library for visualizing geospatial data on a web map.
+
+_The project is under **active development**. Some of features and options are subject to change. We welcome contributions of all kinds: bug reports, code contributions and documentation._
 
 ![](./img/banner.png)
 
-bertin.js is an easy to use js library based on [d3js](https://github.com/d3/d3) to facilitate the process of making thematic maps. The principle is to work with layers stacked on each other. As in a GIS, the layers that are displayed above are placed at the top in the code, the layers that are displayed below are placed at the bottom in the code. The layers that can be displayed are of several types: header, footer, graticule, outline, choro, typo, prop, shadow, scalebar, text... Each type has its own parameters. This list will be completed gradually.
+- [Introduction](https://observablehq.com/@neocartocnrs/hello-bertin-js)
+- [Who is Bertin?](#who-is-bertin)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Drawing a map](#drawing-a-map)
+- [Map types](#map-types)
+- [Map components](#map-components)
+- [Other functions](#other-functions)
 
-### Why Bertin ?
+Bertin.js is an easy to use JavaScript library based on [D3.js](https://github.com/d3/d3) makes creating thematic maps simple. The principle is to work with layers stacked on top of one other. Much like in Geographic Information Software (GIS) software, Bertin.js displays layers with a specific hierarchy. The layer at bottom are rendered and then followed by the layer right above it. Some of the layers are used to display various components of a map, some of common layers are: header, footer, graticule, outline, choro, typo, prop, shadow, scalebar, text etc.
 
-Jacques Bertin (1918-2010) was a French cartographer, whose major contribution was a theoretical and practical reflection on all graphic representations (diagrams, maps and graphs), forming the subject of a fundamental treatise, Graphic Semiology, originally published in 1967. Bertin's influence remains strong in the university teaching of cartography today, but also in the circles of statisticians and data visualization specialists.
+### Who is Bertin
 
-## 1. Installation
+Jacques Bertin (1918-2010) was a French cartographer, whose major contribution was a theoretical and practical reflection on all graphic representations (diagrams, maps and graphs), forming the subject of a fundamental treatise, Graphic Semiology, originally published in 1967. Bertin's influence remains strong not only in academics, teaching of cartography today, but also among statisticians and data visualization specialists.
 
-#### <ins>In browser</ins>
+## Installation
+
+#### In browser
 
 Latest version
 
@@ -29,7 +40,7 @@ Pinned version
 ></script>
 ```
 
-#### <ins>In Observable</ins>
+#### In Observable
 
 Latest version
 
@@ -43,9 +54,9 @@ Pinned version
 bertin = require("bertin@0.9.0");
 ```
 
-## 2. How to use?
+## Usage
 
-#### <ins>In browser</ins>
+#### In browser
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
@@ -53,47 +64,48 @@ bertin = require("bertin@0.9.0");
 <script src="https://cdn.jsdelivr.net/npm/bertin"></script>
 
 <script>
+  let geojson =
+    "https://raw.githubusercontent.com/neocarto/bertin/main/data/world.geojson";
 
-let geojson = "https://raw.githubusercontent.com/neocarto/bertin/main/data/world.geojson"
-
-d3.json(geojson).then(r =>
-document.body.appendChild(bertin.draw({
-  params: {
-    projection: d3.geoVanDerGrinten4(),
-    clip:true
-  },
-  layers: [
-      {geojson: r,  tooltip: ["$ISO3", "$NAMEen"] },
-      {type:"outline"},
-      {type:"graticule"}
-    ]
-})));
-
+  d3.json(geojson).then((r) =>
+    document.body.appendChild(
+      bertin.draw({
+        params: {
+          projection: d3.geoVanDerGrinten4(),
+          clip: true,
+        },
+        layers: [
+          { geojson: r, tooltip: ["$ISO3", "$NAMEen"] },
+          { type: "outline" },
+          { type: "graticule" },
+        ],
+      })
+    )
+  );
 </script>
 ```
 
 See examples [here](https://neocarto.github.io/bertin/examples/example1.html) and [there](https://neocarto.github.io/bertin/examples/example2.html) and [there](https://neocarto.github.io/bertin/examples/example3.html).
 
-#### <ins>In Observable</ins>
+#### In Observable
 
-The bertin.js library is really easy to use within Observable. You'll find many examples in [this collection](https://observablehq.com/collection/@neocartocnrs/bertin).
+The bertin.js library is really easy to use within a Observable notebook. You'll find many examples in [this notebook collection](https://observablehq.com/collection/@neocartocnrs/bertin).
 
-#### <ins>Examples</ins>
+#### Examples
 
 Many examples are available on [Observable](https://observablehq.com/collection/@neocartocnrs/bertin). Feel free to fork, copy, modify with your own data.
 
 [![](./img/obs.png)](https://observablehq.com/collection/@neocartocnrs/bertin)
 
+## Drawing a map
 
-## 3. bertin.draw
+**draw**() is the main function of the library. It allows you to make various thematic maps. It allows to display and overlay different types of layers listed below. The layers written on top are displayed first. [Example](https://observablehq.com/@neocartocnrs/hello-bertin-js)
 
-<b>draw</b>() is the main function of the library. It allows you to make various thematic maps. It allows to display and overlay different types of layers listed below. The layers written on top are displayed first. [Example](https://observablehq.com/@neocartocnrs/hello-bertin-js)
-
-#### <ins>Global parameters</ins>
+#### Global parameters
 
 In the section _params_, we define the global parameters of the map: its size, projection, background color, etc. To have access to a large number of projections, you will need to load the [d3-geo-projection@4](https://github.com/d3/d3-geo-projection) library. This section is optional.
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -105,26 +117,22 @@ bertin.draw({
 })
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
+- **projection**: a d3 function or proj4string defining the map projection. [d3-geo-projection@4](https://github.com/d3/d3-geo-projection) & [https://spatialreference.org](https://spatialreference.org/) (default: d3.geoEquirectangular()) [Example](https://observablehq.com/@neocartocnrs/bertin-js-projections)
+- **width**: width of the map (default:1000);
+- **extent**: a feature or a bbox array defining the extent e.g. a country or [[112, -43],[153, -9]] (default: null)
+- **margin**: margin around features to be displayed. This option can be useful if the stroke is very heavy (default: 1)
+- **background**: color of the background (default: "none")
+- **clip**: a boolean to avoid artifacts of discontinuous projection (default: "false")
 
-- <b>projection</b>: a d3 function or proj4string defining the map projection. Cf [d3-geo-projection@4](https://github.com/d3/d3-geo-projection) & [https://spatialreference.org](https://spatialreference.org/) (default: d3.geoEquirectangular()). [Example](https://observablehq.com/@neocartocnrs/bertin-js-projections)
-- <b>width</b>: width of the map (default:1000);
-- <b>extent</b>: a feature or a bbox array defining the extent e.g. a country or [[112, -43],[153, -9]] (default: null)
-- <b>margin</b>: margin around features to be displayed. This option can be useful if the stroke is very heavy (default: 1)
-- <b>background</b>: color of the background (default: "none")
-- <b>clip</b>: a boolen to avoid artefacts of discontinuous projection (default: "false")
-
-</details>
-
-## 4. Map types
+## Map types
 
 #### Simple layer
 
-The _layer_ type allows to display a simple geojson layer (points, lines or polygons). [Source](https://github.com/neocarto/bertin/blob/main/src/layers/simple.js). [Example 1](https://observablehq.com/@neocartocnrs/hello-bertin-js). [Example 2](https://observablehq.com/@neocartocnrs/bertin-js-symbols?collection=@neocartocnrs/bertin)
+The _layer_ type allows to display a simple geojson layer (points, lines or polygons). [Source](https://github.com/neocarto/bertin/blob/main/src/layer-simple.js). [Example 1](https://observablehq.com/@neocartocnrs/hello-bertin-js). [Example 2](https://observablehq.com/@neocartocnrs/bertin-js-symbols?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -138,47 +146,43 @@ bertin.draw({
 })
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>geojson</b>: a geojson (<ins>compulsory<ins>)
-- <b>fill</b>: fill color (default: a random color)
-- <b>stroke</b>: stroke color (default: "white")
-- <b>strokeWidth</b> stroke width (default:0.5)
-- <b>strokeLinecap</b>: stroke-linecap (default:"round")
-- <b>strokeLinejoin</b>: stroke-linejoin (default:"round")
-- <b>strokeDasharray</b>: stroke-dasharray (default:"none")
-- <b>fillOpacity</b>: fill opacity (default:1)
-- <b>fillOpacity</b>: fill opacity (default:1)
-- <b>symbol</b>: if it is a dot layer, the type of symbol. "circle", "cross", "diamond", "square", "star", "triangle", "wye" (default: "circle")
-- <b>symbol_size</b>: if it is a dot layer, a number indicating the size of the symbol (default: 5)
-- <b>symbol_shift</b>: if it is a dot layer, use a value > 0 to switch symbols and avoid overlay (default: 0)
-- <b>symbol_iteration</b>: Number of iteration tu shift symbols (default: 200)
+- **geojson**: a geojson (**compulsory**)
+- **fill**: fill color (default: a random color)
+- **stroke**: stroke color (default: "white")
+- **strokeWidth** stroke width (default:0.5)
+- **strokeLinecap**: stroke-linecap (default:"round")
+- **strokeLinejoin**: stroke-linejoin (default:"round")
+- **strokeDasharray**: stroke-dasharray (default:"none")
+- **fillOpacity**: fill opacity (default:1)
+- **fillOpacity**: fill opacity (default:1)
+- **symbol**: if it is a dot layer, the type of symbol. "circle", "cross", "diamond", "square", "star", "triangle", "wye" (default: "circle")
+- **symbol_size**: if it is a dot layer, a number indicating the size of the symbol (default: 5)
+- **symbol_shift**: if it is a dot layer, use a value > 0 to switch symbols and avoid overlay (default: 0)
+- **symbol_iteration**: Number of iteration tu shift symbols (default: 200)
 
 Parameters of the legend
 
-- <b>leg_x</b>: position in x (if this value is not filled, the legend is not displayed)
-- <b>leg_y</b>: position in y (if this value is not filled, the legend is not displayed)
-- <b>leg_w</b>: width of the bof (default: 30)
-- <b>leg_h</b>: height of the bof (default:20)
-- <b>leg_title</b>: title of the legend (default; null)
-- <b>leg_text</b>: text of the box (default: "text of the box")
-- <b>leg_fontSize</b>: title legend font size (default: 14)
-- <b>leg_fontSize2</b>: values font size (default: 10)
-- <b>leg_fill</b>: color of the box (same as the layer displayed)
-- <b>leg_stroke</b>: stroke of the box (default: "black")
-- <b>leg_strokeWidth</b>: stroke-width (default: 0.5)
-- <b>leg_fillOpacity</b>: stroke opacity (same as the layer displayed)
-- <b>leg_txtcol</b>: color of the text (default: "#363636")
-
-</details>
+- **leg_x**: position in x (if this value is not filled, the legend is not displayed)
+- **leg_y**: position in y (if this value is not filled, the legend is not displayed)
+- **leg_w**: width of the bof (default: 30)
+- **leg_h**: height of the bof (default:20)
+- **leg_title**: title of the legend (default; null)
+- **leg_text**: text of the box (default: "text of the box")
+- **leg_fontSize**: title legend font size (default: 14)
+- **leg_fontSize2**: values font size (default: 10)
+- **leg_fill**: color of the box (same as the layer displayed)
+- **leg_stroke**: stroke of the box (default: "black")
+- **leg_strokeWidth**: stroke-width (default: 0.5)
+- **leg_fillOpacity**: stroke opacity (same as the layer displayed)
+- **leg_txtcol**: color of the text (default: "#363636")
 
 #### Choropleth
 
 The _choro_ type aims to draw Choropleth maps. This kind of representation is especially suitable for relative quantitative data (rates, indices, densities). The choro type can be applied to the fill or stroke property of a simple layer. [Example](https://observablehq.com/@neocartocnrs/bertin-js-chropoleth?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -201,44 +205,41 @@ bertin.draw({
 })
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>values</b>: a string corresponding to the targeted variable in the properties(<ins>compulsory<ins>)
-- <b>pal</b>: a palette of categorical colors (default: "Blues") [See](https://observablehq.com/@d3/color-schemes)
-- <b>nbreaks</b>: Number of classes (default:5)
-- <b>breaks</b>: Class breaks (default:null)
-- <b>colors</b>: An array of colors (default: null)
-- <b>method</b>: A method of classification. Jenks, q6, quantiles, msd (mean standard deviation), equal (default: quantiles). See [statsbreaks](https://observablehq.com/@neocartocnrs/hello-statsbreaks)
-- <b>middle</b>: for msd method only. middle class or not  (default:false);
-- <b>k</b>: for  msd method only. number of sd. (default:1);
-- <b>col_missing</b>: Color for missing values (default "#f5f5f5")
-- <b>stroke</b>: stroke color (default: "white")
-- <b>strokeWidth</b>: Stroke width (default: 0.5)
-- <b>fillOpacity</b>: Fill opacity (default: 1)
+- **values**: a string corresponding to the targeted variable in the properties(**compulsory**)
+- **pal**: a palette of categorical colors (default: "Blues") [See](https://observablehq.com/@d3/color-schemes)
+- **nbreaks**: Number of classes (default:5)
+- **breaks**: Class breaks (default:null)
+- **colors**: An array of colors (default: null)
+- **method**: A method of classification. Jenks, q6, quantiles, msd (mean standard deviation), equal (default: quantiles). See [statsbreaks](https://observablehq.com/@neocartocnrs/hello-statsbreaks)
+- **middle**: for msd method only. middle class or not (default:false);
+- **k**: for msd method only. number of sd. (default:1);
+- **col_missing**: Color for missing values (default "#f5f5f5")
+- **stroke**: stroke color (default: "white")
+- **strokeWidth**: Stroke width (default: 0.5)
+- **fillOpacity**: Fill opacity (default: 1)
 
 Parameters of the legend
 
-- <b>leg_x</b>: position in x (if this value is not filled, the legend is not displayed)
-- <b>leg_y</b>: position in y (if this value is not filled, the legend is not displayed)
-- <b>leg_w</b>: width of the bof (default: 30)
-- <b>leg_h</b>: height of the bof (default:20)
-- <b>leg_text</b>: text of the box (default: "text of the box")
-- <b>leg_fontSize</b>: text font size (default: 10)
-- <b>leg_fill</b>: color of the box (same as the layer displayed)
-- <b>leg_stroke</b>: stroke of the box (default: "black")
-- <b>leg_strokeWidth</b>: stroke-width (default: 0.5)
-- <b>leg_fillOpacity</b>: stroke opacity (same as the layer displayed)
-- <b>leg_txtcol</b>: color of the text (default: "#363636")
-- <b>leg_round</b>: Number of digits (default: undefined)
-</details>
+- **leg_x**: position in x (if this value is not filled, the legend is not displayed)
+- **leg_y**: position in y (if this value is not filled, the legend is not displayed)
+- **leg_w**: width of the bof (default: 30)
+- **leg_h**: height of the bof (default:20)
+- **leg_text**: text of the box (default: "text of the box")
+- **leg_fontSize**: text font size (default: 10)
+- **leg_fill**: color of the box (same as the layer displayed)
+- **leg_stroke**: stroke of the box (default: "black")
+- **leg_strokeWidth**: stroke-width (default: 0.5)
+- **leg_fillOpacity**: stroke opacity (same as the layer displayed)
+- **leg_txtcol**: color of the text (default: "#363636")
+- **leg_round**: Number of digits (default: undefined)
 
 #### Typology
 
 The _typo_ type allows to realize a qualitative map. The choro type can be applied to the fill or stroke property of a simple layer. [Example](https://observablehq.com/@neocartocnrs/bertin-js-typo?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -259,39 +260,35 @@ layers: [
 })
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>values</b>: a string corresponding to the targeted variable in the properties (<ins>compulsory<ins>)
-- <b>colors</b>: An array containing n colors for n types (default: null)
-- <b>pal</b>: a palette of categorical colors (default: "Tableau10") [See](https://observablehq.com/@d3/color-schemes)
-- <b>col_missing</b>: Color for missing values (default "#f5f5f5")
-- <b>stroke</b>: stroke color (default: "white")
-- <b>strokeWidth</b>: Stroke width (default: 0.5)
-- <b>fillOpacity</b>: Fill opacity (default: 1)
+- **values**: a string corresponding to the targeted variable in the properties (**compulsory**)
+- **colors**: An array containing n colors for n types (default: null)
+- **pal**: a palette of categorical colors (default: "Tableau10") [See](https://observablehq.com/@d3/color-schemes)
+- **col_missing**: Color for missing values (default "#f5f5f5")
+- **stroke**: stroke color (default: "white")
+- **strokeWidth**: Stroke width (default: 0.5)
+- **fillOpacity**: Fill opacity (default: 1)
 
 Parameters of the legend
 
-- <b>leg_x</b>: position in x (if this value is not filled, the legend is not displayed)
-- <b>leg_y</b>: position in y (if this value is not filled, the legend is not displayed)
-- <b>leg_w</b>: width of the bof (default: 30)
-- <b>leg_h</b>: height of the bof (default:20)
-- <b>leg_title</b>: title of the legend (default; null)
-- <b>leg_fontSize</b>: title legend font size (default: 14)
-- <b>leg_fontSize2</b>: values font size (default: 10)
-- <b>leg_stroke</b>: stroke of the box (default: "black")
-- <b>leg_strokeWidth</b>: stroke-width (default: 0.5)
-- <b>leg_fillOpacity</b>: stroke opacity (same as the layer displayed)
-- <b>leg_txtcol</b>: color of the text (default: "#363636")
-
-</details>
+- **leg_x**: position in x (if this value is not filled, the legend is not displayed)
+- **leg_y**: position in y (if this value is not filled, the legend is not displayed)
+- **leg_w**: width of the bof (default: 30)
+- **leg_h**: height of the bof (default:20)
+- **leg_title**: title of the legend (default; null)
+- **leg_fontSize**: title legend font size (default: 14)
+- **leg_fontSize2**: values font size (default: 10)
+- **leg_stroke**: stroke of the box (default: "black")
+- **leg_strokeWidth**: stroke-width (default: 0.5)
+- **leg_fillOpacity**: stroke opacity (same as the layer displayed)
+- **leg_txtcol**: color of the text (default: "#363636")
 
 #### Bubble
 
-The _bubble_ type is used to draw a map by proportional circles. [Source](https://github.com/neocarto/bertin/blob/main/src/layers/bubble.js) [Example](https://observablehq.com/@neocartocnrs/bertin-js-prop-symbols?collection=@neocartocnrs/bertin)
+The _bubble_ type is used to draw a map by proportional circles. [Source](https://github.com/neocarto/bertin/blob/main/src/layer-bubble.js) [Example](https://observablehq.com/@neocartocnrs/bertin-js-prop-symbols?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -307,42 +304,38 @@ bertin.draw({
 });
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>geojson</b>: a geojson (<ins>compulsory<ins>)
-- <b>values</b>: a string corresponding to the targeted variable in the properties(<ins>compulsory<ins>)
-- <b>k</b>: size of the largest circle (default:50)
-- <b>fixmax</b>: Max value to fix the size of the biggest circle, in order to make maps comparable (default:undefined)
-- <b>fill</b>: fill color (default: random color)
-- <b>stroke</b>: stroke color (default: "white")
-- <b>strokeWidth</b>: stroke width (default: 0.5)
-- <b>fillOpacity</b>: fill opacity (default: 1)
-- <b>dorling</b>: a boolean (default:false)
-- <b>iteration</b> an integer to define the number of iteration for the Dorling method (default 200)
-- <b>tooltip</b> an array of values defining what to display within the tooltip. If you use a $, the value within the geojson is displayed. [Example](https://observablehq.com/@neocartocnrs/bertin-js-tooltips?collection=@neocartocnrs/bertin)
+- **geojson**: a geojson (**compulsory**)
+- **values**: a string corresponding to the targeted variable in the properties(**compulsory**)
+- **k**: size of the largest circle (default:50)
+- **fixmax**: Max value to fix the size of the biggest circle, in order to make maps comparable (default:undefined)
+- **fill**: fill color (default: random color)
+- **stroke**: stroke color (default: "white")
+- **strokeWidth**: stroke width (default: 0.5)
+- **fillOpacity**: fill opacity (default: 1)
+- **dorling**: a boolean (default:false)
+- **iteration** an integer to define the number of iteration for the Dorling method (default 200)
+- **tooltip** an array of values defining what to display within the tooltip. If you use a $, the value within the geojson is displayed. [Example](https://observablehq.com/@neocartocnrs/bertin-js-tooltips?collection=@neocartocnrs/bertin)
 
 Parameters of the legend
 
-- <b>leg_x</b>: position in x (if this value is not filled, the legend is not displayed)
-- <b>leg_y</b>: position in y (if this value is not filled, the legend is not displayed)
-- <b>leg_fill</b>: color of the circles (default: "none")
-- <b>leg_stroke</b>: stroke of the circles (default: "black")
-- <b>leg_strokeWidth</b>: stoke-width (default: 0.8)
-- <b>leg_txtcol</b>: color of the text (default: "#363636")
-- <b>leg_title</b>: title of the legend (default var_data)
-- <b>leg_round</b>: number of digits after the decimal point (default: undefined)
-- <b>leg_fontSize</b>: title legend font size (default: 14)
-- <b>leg_fontSize2</b>: values font size (default: 10)
-
-</details>
+- **leg_x**: position in x (if this value is not filled, the legend is not displayed)
+- **leg_y**: position in y (if this value is not filled, the legend is not displayed)
+- **leg_fill**: color of the circles (default: "none")
+- **leg_stroke**: stroke of the circles (default: "black")
+- **leg_strokeWidth**: stoke-width (default: 0.8)
+- **leg_txtcol**: color of the text (default: "#363636")
+- **leg_title**: title of the legend (default var_data)
+- **leg_round**: number of digits after the decimal point (default: undefined)
+- **leg_fontSize**: title legend font size (default: 14)
+- **leg_fontSize2**: values font size (default: 10)
 
 #### Stock + ratio
 
 In thematic mapping, we often have to represent an absolute quantitative data with a size variation and relative quantitative data with color variations. For this we can use the bubble type + the choro type. [Example](https://observablehq.com/d/31a3309790d7bed9?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -365,13 +358,11 @@ bertin.draw({
 });
 ```
 
-</details>
-
 #### Stock + typo
 
 In thematic mapping, we often have to represent an absolute quantitative data with a size variation and relative quantitative data with color variations. For this we can use the bubble type + the typo type. [Example](https://observablehq.com/d/8c9b22ccdffc718d?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -389,13 +380,11 @@ bertin.draw({
 });
 ```
 
-</details>
-
 #### Dorling cartogram
 
 The _dorling_ parameter can be used with the _bubble_ type to design a Dorling cartogram. [Example](https://observablehq.com/@neocartocnrs/bertin-js-dorling-cartogram?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -413,133 +402,122 @@ bertin.draw({
 });
 ```
 
-</details>
-
 #### Dots cartogram
 
-The _dotcartogram_ type is a method of map representation that follows Dorling's cartograms and dot density maps. The data from each territorial unit are dissolved in such a way that a dot represents a constant quantity, the same on the whole map. [Source](https://github.com/neocarto/bertin/blob/main/src/layer/dotcartogram.js) [Example](https://observablehq.com/@neocartocnrs/bertin-js-dots-cartograms?collection=@neocartocnrs/bertin)
+The _dotcartogram_ type is a method of map representation that follows Dorling's cartograms and dot density maps. The data from each territorial unit are dissolved in such a way that a dot represents a constant quantity, the same on the whole map. [Example](https://observablehq.com/@neocartocnrs/bertin-js-dots-cartograms?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
+
 ```js
-
 bertin.draw({
-params: { projection: d3.geoBertin1953() },
-layers: [
-{
-type: "dotcartogram",
-geojson: data,
-onedot: 200000000000,
-iteration: 200,
-values: "gdp",
-radius: radius,
-span: span,
-leg_fill: "none",
-leg_stroke: "black",
-leg_strokeWidth: 1.5,
-leg_x: 800,
-leg_y: 450,
-leg_title: `GDP by world region`,
-leg_txt: "200 billion $",
-fill: "red",
-tooltip: ["$name", "$region"]
-}
-]
-})
+  params: { projection: d3.geoBertin1953() },
+  layers: [
+    {
+      type: "dotcartogram",
+      geojson: data,
+      onedot: 200000000000,
+      iteration: 200,
+      values: "gdp",
+      radius: radius,
+      span: span,
+      leg_fill: "none",
+      leg_stroke: "black",
+      leg_strokeWidth: 1.5,
+      leg_x: 800,
+      leg_y: 450,
+      leg_title: `GDP by world region`,
+      leg_txt: "200 billion $",
+      fill: "red",
+      tooltip: ["$name", "$region"],
+    },
+  ],
+});
+```
 
-````
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>geojson</b>: a geojson (<ins>compulsory<ins>)
-- <b>values</b>: a string corresponding to the targeted variable in the properties(<ins>compulsory<ins>)
-- <b>radius</b>: radius of dots (default:4)
-- <b>nbmax</b>: number max of circles on the map (default:200)
-- <b>onedot</b>: dot value (if onedot is filled, nbmax is useless)
-- <b>span></b>: spacing between dots (default 0.5)
-<b>fill </b>:
-- <b>fill</b>: fill color (default: random color)
-- <b>stroke</b>: stroke color (default: "white")
-- <b>strokeWidth</b>: stroke width (default: 0.5)
-- <b>fillOpacity</b>: fill opacity (default: 1)
-- <b>tooltip</b> an array of values defining what to display within the tooltip. If you use a $, the value within the geojson is displayed.
-- <b>iteration</b> an integer to define the number of iteration for the Dorling method (default 200)
+- **geojson**: a geojson (**compulsory**)
+- **values**: a string corresponding to the targeted variable in the properties(**compulsory**)
+- **radius**: radius of dots (default:4)
+- **nbmax**: number max of circles on the map (default:200)
+- **onedot**: dot value (if onedot is filled, nbmax is useless)
+- **span**: spacing between dots (default 0.5)
+- **fill**: fill color (default: random color)
+- **stroke**: stroke color (default: "white")
+- **strokeWidth**: stroke width (default: 0.5)
+- **fillOpacity**: fill opacity (default: 1)
+- **tooltip** an array of values defining what to display within the tooltip. If you use a $, the value within the geojson is displayed.
+- **iteration** an integer to define the number of iteration for the Dorling method (default 200)
 
 Parameters of the legend
 
-- <b>leg_x</b>: position in x (if this value is not filled, the legend is not displayed)
-- <b>leg_y</b>: position in y (if this value is not filled, the legend is not displayed)
-- <b>leg_fill</b>: color of the circles (default: "none")
-- <b>leg_stroke</b>: stroke of the circles (default: "black")
-- <b>leg_strokeWidth</b>: stoke-width (default: 0.8)
-- <b>leg_txtcol</b>: color of the text (default: "#363636")
-- <b>leg_title</b>: title of the legend (default var_data)
-- <b>leg_txt</b>: text in the legend (default onedot value)
-- <b>leg_fontSize</b>: title legend font size (default: 14)
-- <b>leg_fontSize2</b>: text font size (default: 10)
-
-</details>
+- **leg_x**: position in x (if this value is not filled, the legend is not displayed)
+- **leg_y**: position in y (if this value is not filled, the legend is not displayed)
+- **leg_fill**: color of the circles (default: "none")
+- **leg_stroke**: stroke of the circles (default: "black")
+- **leg_strokeWidth**: stoke-width (default: 0.8)
+- **leg_txtcol**: color of the text (default: "#363636")
+- **leg_title**: title of the legend (default var_data)
+- **leg_txt**: text in the legend (default onedot value)
+- **leg_fontSize**: title legend font size (default: 14)
+- **leg_fontSize2**: text font size (default: 10)
 
 #### Mushroom
 
-The *mushroom* type is used to draw a map with 2 superposed proportional semi-circles. This type of representation can be used when 2 data with the same order of magnitude need to be compressed. [Source](https://github.com/neocarto/bertin/blob/main/src/layer/mushroom.js) [Example](https://observablehq.com/d/3c51f698ba19546c?collection=@neocartocnrs/bertin)
+The _mushroom_ type is used to draw a map with 2 superposed proportional semi-circles. This type of representation can be used when 2 data with the same order of magnitude need to be compressed. [Source](https://github.com/neocarto/bertin/blob/main/src/layer-mushroom.js) [Example](https://observablehq.com/d/3c51f698ba19546c?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
-  bertin.draw({
-    layers: [
-      {
-        type: "mushroom",
-        geojson: mygeojson,
-        top_values: "gdp_pct",
-        bottom_values: "pop_pct",
-        bottom_tooltip: ["name", "pop", "(thousands inh.)"],
-        top_tooltip: ["name", "gdp", "(million $)"]
-      }
-    ]
-  })
-````
+bertin.draw({
+  layers: [
+    {
+      type: "mushroom",
+      geojson: mygeojson,
+      top_values: "gdp_pct",
+      bottom_values: "pop_pct",
+      bottom_tooltip: ["name", "pop", "(thousands inh.)"],
+      top_tooltip: ["name", "gdp", "(million $)"],
+    },
+  ],
+});
+```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>geojson</b>: a geojson (<ins>compulsory<ins>)
-- <b>top_values</b>: a string corresponding to the targeted top variable in the properties (<ins>compulsory<ins>)
-- <b>bottom_values</b>: a string corresponding to the targeted bottom variable in the properties(<ins>compulsory<ins>)
-- <b>top_fill</b>: top fill color (default: "#d64f4f")
-- <b>bottom_fill</b>: bottom fill color (default: "#4fabd6")
-- <b>k</b>: size of the largest semi circle (default:50)
-- <b>stroke</b>: stroke color (default: "white")
-- <b>strokeWidth</b>: stroke width (default: 0.5)
-- <b>fillOpacity</b>: fill opacity (default: 1)
-- <b>top_tooltip</b>:  an array of values defining what to display within the tooltip. If you use a $, the value within the geojson is displayed.
-- <b>bottom_tooltip</b>: an array of values defining what to display within the tooltip. If you use a $, the value within the geojson is displayed.
+- **geojson**: a geojson (**compulsory**)
+- **top_values**: a string corresponding to the targeted top variable in the properties (**compulsory**)
+- **bottom_values**: a string corresponding to the targeted bottom variable in the properties(**compulsory**)
+- **top_fill**: top fill color (default: "#d64f4f")
+- **bottom_fill**: bottom fill color (default: "#4fabd6")
+- **k**: size of the largest semi circle (default:50)
+- **stroke**: stroke color (default: "white")
+- **strokeWidth**: stroke width (default: 0.5)
+- **fillOpacity**: fill opacity (default: 1)
+- **top_tooltip**: an array of values defining what to display within the tooltip. If you use a $, the value within the geojson is displayed.
+- **bottom_tooltip**: an array of values defining what to display within the tooltip. If you use a $, the value within the geojson is displayed.
 
 Parameters of the legend
 
-- <b>leg_x</b>: position in x (if this value is not filled, the legend is not displayed)
-- <b>leg_y</b>: position in y (if this value is not filled, the legend is not displayed)
-- <b>leg_fontSize</b>: title legend font size (default: 14)
-- <b>leg_fontSize2</b>: values font size (default: 10)
-- <b>leg_round</b>: number of digits after the decimal point (default: undefined)
-- <b>leg_txtcol</b>: color of the text (default: "#363636")
-- <b>leg_title</b>: title of the legend (default "Title, year")
-- <b>leg_stroke</b>: stroke of the circles (default: "black")
-- <b>leg_top_txt</b> title for the top variable (default top_var)
-- <b>leg_bottom_txt</b> title for the bottom variable (default bottom_var)
-- <b>leg_top_fill</b> color of top semi circles (default same as top_fill)
-- <b>leg_bottom_fill</b> color of bottom semi circles (default same as bottom_fill)
-- <b>leg_strokeWidth</b> stroke width of elements in the legend (default 0.8)
-
-</details>
+- **leg_x**: position in x (if this value is not filled, the legend is not displayed)
+- **leg_y**: position in y (if this value is not filled, the legend is not displayed)
+- **leg_fontSize**: title legend font size (default: 14)
+- **leg_fontSize2**: values font size (default: 10)
+- **leg_round**: number of digits after the decimal point (default: undefined)
+- **leg_txtcol**: color of the text (default: "#363636")
+- **leg_title**: title of the legend (default "Title, year")
+- **leg_stroke**: stroke of the circles (default: "black")
+- **leg_top_txt** title for the top variable (default top_var)
+- **leg_bottom_txt** title for the bottom variable (default bottom_var)
+- **leg_top_fill** color of top semi circles (default same as top_fill)
+- **leg_bottom_fill** color of bottom semi circles (default same as bottom_fill)
+- **leg_strokeWidth** stroke width of elements in the legend (default 0.8)
 
 #### Spikes
 
-The _spikes_ type is used to draw a map with spikes. [Source](https://github.com/neocarto/bertin/blob/main/src/layers/spikes.js) [Example](https://observablehq.com/d/12446a15a2642907?collection=@neocartocnrs/bertin)
+The _spikes_ type is used to draw a map with spikes. [Source](https://github.com/neocarto/bertin/blob/main/src/layer-spikes.js) [Example](https://observablehq.com/d/12446a15a2642907?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -556,42 +534,38 @@ bertin.draw({
 });
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>geojson</b>: a geojson (<ins>compulsory<ins>)
-- <b>values</b>: a string corresponding to the targeted variable in the properties(<ins>compulsory<ins>)
-- <b>k</b>: height of the highest peak (default:50)
-- <b>w</b>: width of the spikes (default:10)
-- <b>fill</b>: fill color (default: #a31d88)
-- <b>stroke</b>: stroke color (default: #a31d88)
-- <b>strokeWidth</b>: stroke width (default: 0.7)
-- <b>fillOpacity</b>: fill opacity (default: 0.3)
-- <b>tooltip</b> an array of values defining what to display within the tooltip. If you use a $, the value within the geojson is displayed.
+- **geojson**: a geojson (**compulsory**)
+- **values**: a string corresponding to the targeted variable in the properties(**compulsory**)
+- **k**: height of the highest peak (default:50)
+- **w**: width of the spikes (default:10)
+- **fill**: fill color (default: #a31d88)
+- **stroke**: stroke color (default: #a31d88)
+- **strokeWidth**: stroke width (default: 0.7)
+- **fillOpacity**: fill opacity (default: 0.3)
+- **tooltip** an array of values defining what to display within the tooltip. If you use a $, the value within the geojson is displayed.
 
 Parameters of the legend
 
-- <b>leg_x</b>: position in x (if this value is not filled, the legend is not displayed)
-- <b>leg_y</b>: position in y (if this value is not filled, the legend is not displayed)
-- <b>leg_fill</b>: color of the circles (default: "none")
-- <b>leg_stroke</b>: stroke of the circles (default: "black")
-- <b>leg_strokeWidth</b>: stoke-width (default: 0.8)
-- <b>leg_txtcol</b>: color of the text (default: "#363636")
-- <b>leg_title</b>: title of the legend (default var_data)
-- <b>leg_round</b>: rounding (default: undefined)
-- <b>leg_fontSize</b>: title legend font size (default: 14)
-- <b>leg_fontSize2</b>: values font size (default: 10)
+- **leg_x**: position in x (if this value is not filled, the legend is not displayed)
+- **leg_y**: position in y (if this value is not filled, the legend is not displayed)
+- **leg_fill**: color of the circles (default: "none")
+- **leg_stroke**: stroke of the circles (default: "black")
+- **leg_strokeWidth**: stoke-width (default: 0.8)
+- **leg_txtcol**: color of the text (default: "#363636")
+- **leg_title**: title of the legend (default var_data)
+- **leg_round**: rounding (default: undefined)
+- **leg_fontSize**: title legend font size (default: 14)
+- **leg_fontSize2**: values font size (default: 10)
 
-</details>
-
-## 5. Map staging
+## Map components
 
 #### Footer
 
-The _footer_ type allows to display text under the map. This is useful to display sources. [Source](https://github.com/neocarto/bertin/blob/main/src/layers/footer.js).
+The _footer_ type allows to display text under the map. This is useful to display sources. [Source](https://github.com/neocarto/bertin/blob/main/src/footer.js).
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -605,24 +579,20 @@ bertin.draw({
 });
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>text</b>: text to be displayed (default:"")
-- <b>anchor</b>: text anchor. start, middle, end (default:"end")
-- <b>fontSize</b>: size of the text (default:15)
-- <b>fill</b>: color of the text (default:"#9e9696")
-- <b>background</b>: background color (default: "white")
-- <b>backgroundOpacity</b>: background opacity (default: 1)
-
-</details>
+- **text**: text to be displayed (default:"")
+- **anchor**: text anchor. start, middle, end (default:"end")
+- **fontSize**: size of the text (default:15)
+- **fill**: color of the text (default:"#9e9696")
+- **background**: background color (default: "white")
+- **backgroundOpacity**: background opacity (default: 1)
 
 #### Graticule
 
-The _graticule_ type allows you to display the latitude and longitude lines.[Source](https://github.com/neocarto/bertin/blob/main/src/layers/graticule.js).
+The _graticule_ type allows you to display the latitude and longitude lines.[Source](https://github.com/neocarto/bertin/blob/main/src/graticule.js).
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -636,23 +606,19 @@ bertin.draw({
 });
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>stroke</b>: stroke color (default:"white")
-- <b>strokeWidth</b>: stroke width (default:0.8)
-- <b>strokeopacity</b>: stroke opacity (default:0.5)
-- <b>strokedasharray</b>stroke-dasharray (default:2)
-- <b>step</b>: gap between graticules. The value can be a number or an array of two values (default:[10, 10])
-
-</details>
+- **stroke**: stroke color (default:"white")
+- **strokeWidth**: stroke width (default:0.8)
+- **strokeopacity**: stroke opacity (default:0.5)
+- **strokedasharray**: stroke-dasharray (default:2)
+- **step**: gap between graticules. The value can be a number or an array of two values (default:[10, 10])
 
 #### Header
 
-The _header_ type allows to display a title above the map. [Source](https://github.com/neocarto/bertin/blob/main/src/layers/header.js).
+The _header_ type allows to display a title above the map. [Source](https://github.com/neocarto/bertin/blob/main/src/header.js).
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -666,24 +632,20 @@ bertin.draw({
 });
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>text</b>: text to be displayed (default:"")
-- <b>anchor</b>: text anchor. start, middle, end (default:"middle")
-- <b>fontSize</b>: size of the text (default:20)
-- <b>fill</b>: color of the text (default:"#9e9696")
-- <b>background</b>: background color (default: "white")
-- <b>backgroundOpacity</b>: background opacity (default: 1)
-
-</details>
+- **text**: text to be displayed (default:"")
+- **anchor**: text anchor. start, middle, end (default:"middle")
+- **fontSize**: size of the text (default:20)
+- **fill**: color of the text (default:"#9e9696")
+- **background**: background color (default: "white")
+- **backgroundOpacity**: background opacity (default: 1)
 
 #### Labels
 
-The _label_ type allows to display labels from a geojson. [Source](https://github.com/neocarto/bertin/blob/main/src/layers/label.js). [Example](https://observablehq.com/@neocartocnrs/bertin-js-texts)
+The _label_ type allows to display labels from a geojson. [Source](https://github.com/neocarto/bertin/blob/main/src/layer-labels.js). [Example](https://observablehq.com/@neocartocnrs/bertin-js-texts)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -697,26 +659,23 @@ bertin.draw({
 });
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>geojson</b>: a geojson (<ins>compulsory<ins>)
-- <b>values</b>: a string corresponding to the targeted variable in the properties (<ins>compulsory<ins>)
-- <b>fill</b>: fill color (default: "#474342")
-- <b>fontSize</b>: font size (default: 10)
-- <b>fontFamily</b>: font family. "Pacifico","Roboto","Rubik","Ubuntu" (default: "Robotto")
-- <b>textDecoration</b>: text decoration. "none", "underline", "line-through", "overline" (default:"none")
-- <b>fontWeight</b>: font weight. "normal", "bold", "bolder", "lighter" (default: "normal")
-- <b>fontStyle</b>: font style. "normal", "italic", "oblique" (default: "normal")
-- <b>opacity</b>: opacity (default: 1)
-</details>
+- **geojson**: a geojson (**compulsory**)
+- **values**: a string corresponding to the targeted variable in the properties (**compulsory**)
+- **fill**: fill color (default: "#474342")
+- **fontSize**: font size (default: 10)
+- **fontFamily**: font family. "Pacifico","Roboto","Rubik","Ubuntu" (default: "Robotto")
+- **textDecoration**: text decoration. "none", "underline", "line-through", "overline" (default:"none")
+- **fontWeight**: font weight. "normal", "bold", "bolder", "lighter" (default: "normal")
+- **fontStyle**: font style. "normal", "italic", "oblique" (default: "normal")
+- **opacity**: opacity (default: 1)
 
 #### Missing
 
-Sometimes, when making a map by proportional symbols for example, it can be interesting to display in white under the symbols, the countries with missing data. That is what the type _missing_ is for. [Source](https://github.com/neocarto/bertin/blob/main/src/layers/missing.js).
+Sometimes, when making a map by proportional symbols for example, it can be interesting to display in white under the symbols, the countries with missing data. That is what the type _missing_ is for. [Source](https://github.com/neocarto/bertin/blob/main/src/layer-missing.js).
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -729,38 +688,34 @@ bertin.draw({
 })
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>geojson</b>: a geojson (<ins>compulsory<ins>)
-- <b>values</b>: a string corresponding to the targeted variable in the properties (<ins>compulsory<ins>)
-- <b>fill</b>: fill color (default: "white")
-- <b>stroke</b>: stroke color (default: "white")
-- <b>strokeWidth</b>: stroke width (default: 0.5)
-- <b>fillOpacity</b>: fill opacity (default: 1)
+- **geojson**: a geojson (**compulsory**)
+- **values**: a string corresponding to the targeted variable in the properties (**compulsory**)
+- **fill**: fill color (default: "white")
+- **stroke**: stroke color (default: "white")
+- **strokeWidth**: stroke width (default: 0.5)
+- **fillOpacity**: fill opacity (default: 1)
 
 Parameters of the legend
 
-- <b>leg_x</b>: position in x (if this value is not filled, the legend is not displayed)
-- <b>leg_y</b>: position in y (if this value is not filled, the legend is not displayed)
-- <b>leg_w</b>: width of the bof (default: 30)
-- <b>leg_h</b>: height of the bof (default:20)
-- <b>leg_text</b>: text of the box (default: "text of the box")
-- leg_fontSize</b>: text font size (default: 10)
-- <b>leg_fill</b>: color of the box (same as the layer displayed)
-- <b>leg_stroke</b>: stroke of the box (default: "black")
-- <b>leg_strokeWidth</b>: stroke-width (default: 0.5)
-- <b>leg_fillOpacity</b>: stroke opacity (same as the layer displayed)
-- <b>leg_txtcol</b>: color of the text (default: "#363636")
-
-</details>
+- **leg_x**: position in x (if this value is not filled, the legend is not displayed)
+- **leg_y**: position in y (if this value is not filled, the legend is not displayed)
+- **leg_w**: width of the bof (default: 30)
+- **leg_h**: height of the bof (default:20)
+- **leg_text**: text of the box (default: "text of the box")
+- **leg_fontSize**: text font size (default: 10)
+- **leg_fill**: color of the box (same as the layer displayed)
+- **leg_stroke**: stroke of the box (default: "black")
+- **leg_strokeWidth**: stroke-width (default: 0.5)
+- **leg_fillOpacity**: stroke opacity (same as the layer displayed)
+- **leg_txtcol**: color of the text (default: "#363636")
 
 #### Outline
 
-The _outline_ type is used to display the limits of the earth area in the given projection. [Source](https://github.com/neocarto/bertin/blob/main/src/layers/outline.js).
+The _outline_ type is used to display the limits of the earth area in the given projection. [Source](https://github.com/neocarto/bertin/blob/main/src/outline.js).
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -773,22 +728,18 @@ bertin.draw({
 });
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>fill</b>: fill color of the outline (default: "#add8f7")
-- <b>opacity</b>: opacity (default:1)
-- <b>stroke</b>: stroke color (default:"none")
-- <b>strokeWidth</b>: stroke width (default: 1)
-
-</details>
+- **fill**: fill color of the outline (default: "#add8f7")
+- **opacity**: opacity (default:1)
+- **stroke**: stroke color (default:"none")
+- **strokeWidth**: stroke width (default: 1)
 
 #### Scalebar
 
-The _scalebar_ type allows to display a scalebar in miles or kilometers. [Source](https://github.com/neocarto/bertin/blob/main/src/layesr/scalerbar.js)
+The _scalebar_ type allows to display a scalebar in miles or kilometers. [Source](https://github.com/neocarto/bertin/blob/main/src/scalerbar.js)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -801,21 +752,17 @@ bertin.draw({
 });
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>x</b>: position in x (if this value is not filled, the legend is displayed on the left)
-- <b>y</b>: position in x (if this value is not filled, the legend is displayed at the bottom)
-- <b>units</b>: distance unit, miles or kilometers (default: "kilometers")
-
-</details>
+- **x**: position in x (if this value is not filled, the legend is displayed on the left)
+- **y**: position in x (if this value is not filled, the legend is displayed at the bottom)
+- **units**: distance unit, miles or kilometers (default: "kilometers")
 
 #### Shadow
 
-The _shadow_ type allows to display a shadow under a layer to give it a relief effect [Source](https://github.com/neocarto/bertin/blob/main/src/layers/shadow.js)
+The _shadow_ type allows to display a shadow under a layer to give it a relief effect [Source](https://github.com/neocarto/bertin/blob/main/src/shadow.js)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -830,23 +777,19 @@ bertin.draw({
 });
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>col</b>: color (default: "#35383d")
-- <b>dx</b>: shift in x (default: 3)
-- <b>dy</b>: shift in y (default: 3)
-- <b>stdDeviation</b> blur (default: 1.5)
-- <b>opacity</b>: opacity (default: 0.7)
-
-</details>
+- **col**: color (default: "#35383d")
+- **dx**: shift in x (default: 3)
+- **dy**: shift in y (default: 3)
+- **stdDeviation**: blur (default: 1.5)
+- **opacity**: opacity (default: 0.7)
 
 #### Texts
 
 The _text_ type simply allows you to display text anywhere on the map. [Source](https://github.com/neocarto/bertin/blob/main/src/text.js). [Example](https://observablehq.com/d/95fcfac18b213daf?collection=@neocartocnrs/bertin).
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.draw({
@@ -863,92 +806,61 @@ bertin.draw({
 });
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
+- **position**: position of the text. It can be an array with x,y coordinates. For example [100,200]. It can be also a string defining the position. "topleft", "top", "topright", "left", "middle", "right", "bottomleft", "bottom", "bottomright" (default: "topleft")
+- **text**: text to display. With the backticks, it is possible to display a text on several lines (default: "Your text here!")
+- **fontSize**: text size (default: 15)
+- **fontFamily**: font family. "Pacifico","Roboto","Rubik","Ubuntu" (default: "Robotto")
+- **textDecoration**: text decoration. "none", "underline", "line-through", "overline" (default:"none")
+- **fontWeight**: font weight. "normal", "bold", "bolder", "lighter" (default: "normal")
+- **fontStyle**: font style. "normal", "italic", "oblique" (default: "normal")
+- **margin**: margin around the text (default: 0)
+- **anchor**: text anchor. start, middle, end (default: "start")
+- **fill**: text color (default: "#474342")
+- **stroke**: stroke color (default: "none")
+- **frame_fill**: frame background color (default:"none")
+- **frame_stroke**: frame stroke color (default: "none")
+- **frame_strokeWidth**: thickness of the frame contour (default: 1)
+- **frame_opacity**: frame opacity (default: 1)
 
-- <b>position</b>: position of the text. It can be an array with x,y coordinates. For example [100,200]. It can be also a string defining the position. "topleft", "top", "topright", "left", "middle", "right", "bottomleft", "bottom", "bottomright" (default: "topleft")
-- <b>text</b>: text to display. With the backticks, it is possible to display a text on several lines (default: "Your text here!")
-- <b>fontSize</b>: text size (default: 15)
-- <b>fontFamily</b>: font family. "Pacifico","Roboto","Rubik","Ubuntu" (default: "Robotto")
-- <b>textDecoration</b>: text decoration. "none", "underline", "line-through", "overline" (default:"none")
-- <b>fontWeight</b>: font weight. "normal", "bold", "bolder", "lighter" (default: "normal")
-- <b>fontStyle</b>: font style. "normal", "italic", "oblique" (default: "normal")
-- <b>margin</b>: margin around the text (default: 0)
-- <b>anchor</b>: text anchor. start, middle, end (default: "start")
-- <b>fill</b>: text color (default: "#474342")
-- <b>stroke</b>: stroke color (default: "none")
-- <b>frame_fill</b>: frame background color (default:"none")
-- <b>frame_stroke</b>: frame stroke color (default: "none")
-- <b>frame_strokeWidth</b>: thickness of the frame contour (default: 1)
-- <b>frame_opacity</b>: frame opacity (default: 1)
-
-</details>
-
-#### hatch (or hatching)
-
-The _hatch_ type sonly allows to add hatchings on the whole page to make it a bit prettier. [Source](https://github.com/neocarto/bertin/blob/main/src/hatch.js)
-
-<details><summary>Code</summary>
-
-  ```js
-  bertin.draw({
-    layers: [
-      {
-        type: "hatch",
-        angle:45
-      },
-    ],
-  });
-  ```
-
-</details>
-
-  <details><summary>Parameters</summary>
-
-  - <b>stroke</b>: stroke color (default: "#786d6c")
-  - <b>strokeWidth</b>: stroke color (default: 2)
-  - <b>strokeOpacity</b>: stroke-opacity (default: 45)
-  - <b>strokeDasharray</b>: stroke-dasharray (default:"none")
-  - <b>angle</b>: orientation of lines (default: 45)
-  - <b>spacing</b>: spacing beetwen lines (default: 8)
-
-## 6. Other functions
+## Other functions
 
 #### borders
 
 _borders_ is a function that extract borders from polygons, with ids.
 
-<details><summary>Code</summary>
+### Code
+
 ```js
 bertin.borders({geojson: world, id: "iso3", values: "population", type = "rel"})
 ```
-</details>
 
-<details><summary>Code</summary>
+### Code
 
-- <b>geojson</b>: a geojson
-- <b>id</b>: id codes
-- <b>values</b>: values
-- <b>type</b>: type of discontinuites calcuated. rel = relative. abs = absolue (default:"rel")
-
-</details>
+- **geojson**: a geojson
+- **id**: id codes
+- **values**: values
+- **type**: type of discontinuities calculated. rel = relative. abs = absolute (default:"rel")
 
 #### bbox
 
-_bbox_ compute a geojson object form an array defing an extent in latitude and longitude.
+_bbox_ compute a geojson object form an array defining an extent in latitude and longitude.
 
-<details><summary>Code</summary>
+### Code
+
 ```js
-bertin.bbox([[112, -43],[153, -9]])
+bertin.bbox([
+  [112, -43],
+  [153, -9],
+]);
 ```
-</details>
 
 #### Quickdraw
 
 _quickdraw_ is a function to display one or more layers directly and easily. [Source](https://github.com/neocarto/bertin/blob/main/src/quickdraw.js) [Example](https://observablehq.com/d/8d5d24e4d175a0bf?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.quickdraw(geojson);
@@ -958,22 +870,17 @@ bertin.quickdraw(geojson);
 bertin.quickdraw(geojson, 1000, 7);
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- param 1 : a geojson (<ins>compulsory<ins>)
+- param 1 : a geojson (**compulsory**)
 - param 2 : width
 - param 3 : margin
-
-</details>
-
 
 #### Match
 
 _match()_ is a function to evaluate the quality of a join between the data and the background map. It returns a chart. [Source](https://github.com/neocarto/bertin/blob/main/src/match.js) [Example](https://observablehq.com/d/608ed06a679bfeca?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 let testjoin = bertin.match(countries, "ISO3_CODE", maddison, "countrycode");
@@ -1003,22 +910,18 @@ _.unmatched_geom_ returns an array containing unmatched geom ids
 testjoin.unmatched_geom;
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- param 1 : a geojson (<ins>compulsory<ins>)
-- param 2 : a string corresponding to the identifier of the features in the properties (<ins>compulsory<ins>)
-- param 3 : a json (<ins>compulsory<ins>)
-- param 4 : a string corresponding to the identifier of the features (<ins>compulsory<ins>)
-
-</details>
+- param 1 : a geojson (**compulsory**)
+- param 2 : a string corresponding to the identifier of the features in the properties (**compulsory**)
+- param 3 : a json (**compulsory**)
+- param 4 : a string corresponding to the identifier of the features (**compulsory**)
 
 #### Merge
 
 _merge_ is a function to join a geojson and a data file. This is the first step in the mapping process. [Source](https://github.com/neocarto/bertin/blob/main/src/merge.js) [Example](https://observablehq.com/d/608ed06a679bfeca?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 const data = bertin.merge(
@@ -1030,23 +933,19 @@ const data = bertin.merge(
 );
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- param 1 : a geojson (<ins>compulsory<ins>)
-- param 2 : a string corresponding to the identifier of the features in the properties (<ins>compulsory<ins>)
-- param 3 : a json (<ins>compulsory<ins>)
-- param 4 : a string corresponding to the identifier of the features (<ins>compulsory<ins>)
+- param 1 : a geojson (**compulsory**)
+- param 2 : a string corresponding to the identifier of the features in the properties (**compulsory**)
+- param 3 : a json (**compulsory**)
+- param 4 : a string corresponding to the identifier of the features (**compulsory**)
 - param 5 : a boolean. If true, all geometries will be kept. If false, only matched data are kept (default: true)
-
-</details>
 
 #### links
 
 _links_ is a function that create links from geometries (polygons or points) and a data file (i,j,fij). [Example](https://observablehq.com/@neocartocnrs/bertin-js-links)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.links({
@@ -1054,58 +953,52 @@ bertin.links({
   geojson_id: "ISO3",
   data: migr2019,
   data_i: "i",
-  data_j: "j"
-})
+  data_j: "j",
+});
 ```
-</details>
 
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- <b>geojson</b>: a geojson
-- <b>geojson_id</b>: id of the geojson
-- <b>data</b>: inj,fij data
-- <b>data_i</b>: i id
-- <b>data_j</b>: j id
-
-</details>
+- **geojson**: a geojson
+- **geojson_id**: id of the geojson
+- **data**: inj,fij data
+- **data_i**: i id
+- **data_j**: j id
 
 #### subgeo
 
 _subgeo_ is a function to extract a part of a geojson (e.g. world countries without antarctica).
 
-<details><summary>Code</summary>
+### Code
 
 ```js
-bertin.subgeo({geojson: world, field : "iso3", operator : "!=", array:["ATA"]});
+bertin.subgeo({
+  geojson: world,
+  field: "iso3",
+  operator: "!=",
+  array: ["ATA"],
+});
 ```
-</details>
 
-<details><summary>Parameters</summary>
+### Parameters
 
-- <b>geojson</b>: a geojson (or topojson)
-- <b>field</b>: a field in properties
-- <b>operator</b>: an operator (default :"==")
-- <b>array</b>: an array of values
-
-</details>
+- **geojson**: a geojson (or topojson)
+- **field**: a field in properties
+- **operator**: an operator (default :"==")
+- **array**: an array of values
 
 #### Table2geo
 
 _table2geo_ is a function to convert a data table with lat/lon fields to a geojson. [Source](https://github.com/neocarto/bertin/blob/main/src/table2geo.js) [Example](https://observablehq.com/d/8d5d24e4d175a0bf?collection=@neocartocnrs/bertin)
 
-<details><summary>Code</summary>
+### Code
 
 ```js
 bertin.table2geo(cities, "lat", "lng");
 ```
 
-</details>
+### Parameters
 
-<details><summary>Parameters</summary>
-
-- param 1 : a geojson (<ins>compulsory<ins>)
+- param 1 : a geojson (**compulsory**)
 - param 2 : latitude
 - param 3 : longitude
-
-</details>


### PR DESCRIPTION
Reformatted the README for readability. The format of documents allow for quick look up for code examples and follows the style set by Plot documentation. 