### PR TITLE
Fix missing paranthesis closure for some clip-path and filter URLs

### DIFF
--- a/src/layers/geolines.js
+++ b/src/layers/geolines.js
@@ -46,7 +46,7 @@ export function geolines(selection, projection, planar, options = {}, clipid) {
 
       selection
         .append("g")
-        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid}`)
+        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid})`)
         .selectAll("path")
         .data(eq)
         .join("path")
@@ -60,7 +60,7 @@ export function geolines(selection, projection, planar, options = {}, clipid) {
 
       selection
         .append("g")
-        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid}`)
+        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid})`)
         .selectAll("path")
         .data(tr)
         .join("path")
@@ -74,7 +74,7 @@ export function geolines(selection, projection, planar, options = {}, clipid) {
 
       selection
         .append("g")
-        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid}`)
+        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid})`)
         .selectAll("path")
         .data(po)
         .join("path")

--- a/src/layers/graticule.js
+++ b/src/layers/graticule.js
@@ -25,7 +25,7 @@ export function graticule(selection, projection, planar, options = {}, clipid) {
       step = Array.isArray(step) ? step : [step, step];
       selection
         .append("g")
-        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid}`)
+        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid})`)
         .append("path")
         .datum(d3.geoGraticule().step(step))
         .attr("d", d3.geoPath(projection))

--- a/src/layers/inner.js
+++ b/src/layers/inner.js
@@ -42,7 +42,7 @@ export function inner(selection, projection, options = {}) {
 
     selection
       .append("g")
-      .attr("clip-path", `url(#inner${id}`)
+      .attr("clip-path", `url(#inner${id})`)
       .append("path")
       .datum(merged)
       .attr("fill", "none")
@@ -51,7 +51,7 @@ export function inner(selection, projection, options = {}) {
       .attr("stroke-linejoin", "round")
       .attr("stroke-opacity", fillOpacity)
       .attr("stroke-width", thickness * 2)
-      .attr("filter", `url(#blur${id}`)
+      .attr("filter", `url(#blur${id})`)
       .attr("d", d3.geoPath(projection));
   }
 }

--- a/src/layers/minimap.js
+++ b/src/layers/minimap.js
@@ -130,7 +130,7 @@ export function minimap({
     .attr("stroke-opacity", geometries.strokeOpacity)
     .attr("d", path)
     .attr("transform", `translate(${x} ${y})`)
-    .attr("clip-path", `url(#extent_${clipid}`); // ICI
+    .attr("clip-path", `url(#extent_${clipid})`); // ICI
 
   // Outline (stroke)
 
@@ -210,7 +210,7 @@ export function minimap({
     selection
       .append("g")
       .append("path")
-      .attr("clip-path", `url(#clipminimap_${clipid}`)
+      .attr("clip-path", `url(#clipminimap_${clipid})`)
       .datum(geojson)
       .attr("fill", raise.fill)
       .attr("fill-opacity", raise.fillOpacity)

--- a/src/layers/missing.js
+++ b/src/layers/missing.js
@@ -29,7 +29,7 @@ export function missing(selection, projection, options = {}, clipid) {
 
     selection
       .append("g")
-      .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid}`)
+      .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid})`)
       .selectAll("path")
       .data(missing)
       .join("path")

--- a/src/layers/rhumbs.js
+++ b/src/layers/rhumbs.js
@@ -25,7 +25,7 @@ export function rhumbs(selection, width, height, clipid, options = {}) {
 
     selection
       .append("g")
-      .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid}`)
+      .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid})`)
       .selectAll("polyline")
       .data(angles)
       .enter()

--- a/src/layers/shadow.js
+++ b/src/layers/shadow.js
@@ -26,7 +26,7 @@ export function shadow(selection, projection, geojson, clipid, options = {}) {
 
     selection
       .append("g")
-      .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid}`)
+      .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid})`)
       .append("path")
       .datum(merged)
       .attr("d", path)

--- a/src/layers/simple.js
+++ b/src/layers/simple.js
@@ -105,7 +105,7 @@ export function simple(
     if (figuration(geojson) == "l" || figuration(geojson) == "z") {
       selection
         .append("g")
-        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid}`)
+        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid})`)
         .selectAll("path")
         .data(geojson.features)
         .join("path")

--- a/src/layers/tiles.js
+++ b/src/layers/tiles.js
@@ -99,7 +99,7 @@ export function tiles(selection, width, height, projection, options = {}) {
 
     selection
       .append("g")
-      .attr("clip-path", `url(#tileclip_${id}`)
+      .attr("clip-path", `url(#tileclip_${id})`)
       .selectAll("image")
       .data(tile())
       .join("image")

--- a/src/layers/tissot.js
+++ b/src/layers/tissot.js
@@ -15,7 +15,7 @@ export function tissot(selection, projection, planar, options = {}, clipid) {
       let step = options.step ? options.step : 10;
       selection
         .append("g")
-        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid}`)
+        .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid})`)
         .append("path")
         .datum(ts(step))
         .attr("d", geoPath(projection))

--- a/src/layers/waterlines.js
+++ b/src/layers/waterlines.js
@@ -45,7 +45,7 @@ export function waterlines(
 
     selection
       .append("g")
-      .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid}`)
+      .attr("clip-path", clipid == null ? `none` : `url(#clip_${clipid})`)
       .selectAll("path")
       .data(features)
       .join("path")


### PR DESCRIPTION
This does not seem to bother the web browser at all.
However, it looks like Inkscape doesn't like it.

![clippath](https://user-images.githubusercontent.com/12172162/195107543-fad68d42-2390-4893-adcf-7c11692b94be.png)
