### PR TITLE
Using spatial index to speed-up grid based portrayals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "d3-tile": "^1.0.0",
         "jsts": "^2.7.0",
         "proj4": "^2.7.5",
+        "rbush": "^3.0.1",
         "statsbreaks": "^0.3.0",
         "topojson-client": "^3.1.0",
         "topojson-server": "^3.0.1"
@@ -1386,6 +1387,11 @@
         "wkt-parser": "^1.3.1"
       }
     },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1393,6 +1399,14 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
       }
     },
     "node_modules/resolve": {
@@ -2668,6 +2682,11 @@
         "wkt-parser": "^1.3.1"
       }
     },
+    "quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2675,6 +2694,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "requires": {
+        "quickselect": "^2.0.0"
       }
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "d3-tile": "^1.0.0",
     "jsts": "^2.7.0",
     "proj4": "^2.7.5",
+    "rbush": "^3.0.1",
     "statsbreaks": "^0.3.0",
     "topojson-client": "^3.1.0",
     "topojson-server": "^3.0.1"


### PR DESCRIPTION
I propose to use a spatial index (R-Tree, using [RBush](https://github.com/mourner/rbush)) to speed up grid-based calculations for polygons.

In my micro-benchmarks, with the "world" dataset (from here https://observablehq.com/@neocartocnrs/bertin-js-regular-grid) I see computation times divided by 2.5 for a resolution of 100 to computation times divided by 6 for a resolution of 5.

On a slightly larger dataset, such as the French municipalities of region Bretagne (1250 features) I see computation times divided by 3.5 for a resolution of 100 to computation times divided by 20 for a resolution of 10.
