### PR TITLE
Docs: fix minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,7 @@ bertin.draw({
 - **strokeWidth**: stroke width (default: [1.5, 1.2, 0.7])
 - **strokeOpacity**: stroke opacity (default: 1)
 - **strokeDasharray**: stroke-dasharray (default: ["none", 5, 3])
-- **strokeLinecap**: stroke-linecap (default: "but")
+- **strokeLinecap**: stroke-linecap (default: "butt")
 - **display**: Boolean to allow to show or hide the layer. This parameter has no effect on the calculation of the extent. (default: true)
 
 ### Graticule
@@ -1041,7 +1041,7 @@ bertin.draw({
   layers: [
     {
       type: "graticule",
-      fill: "#644580",
+      stroke: "#644580",
       step: [20, 10],
     },
   ],


### PR DESCRIPTION
Just some mistakes I came across while reading the documentation.